### PR TITLE
Include spirv-remap.exe in AppVeyor artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,6 +60,7 @@ after_test:
   # Zip all glslang artifacts for uploading and deploying
   - 7z a glslang-master-windows-"%PLATFORM%"-"%CONFIGURATION%".zip
     bin\glslangValidator.exe
+    bin\spirv-remap.exe
     include\glslang\*
     include\SPIRV\*
     lib\glslang%SUFFIX%.lib


### PR DESCRIPTION
This would help me downstream in [Shader Playground](http://shader-playground.timjones.io/), where I have a build script that downloads a number of compilers, and it's easier to work with existing CLI binaries.

Of course, if there's a reason why `spirv-remap.exe` isn't (yet) included in the AppVeyor artifacts, I can always build from source in my build script.